### PR TITLE
fix for mglaman/contribkanban.com/issues/51 double windows/tabs

### DIFF
--- a/app/scripts/directives.js
+++ b/app/scripts/directives.js
@@ -78,7 +78,7 @@ projectKanbanApp
   .directive('issueNidLink', function () {
     return {
       restrict: 'E',
-      template: '<a class="kanban-board--issue__link" ng-href="https://www.drupal.org/node/{{ issue.nid}}" target="_blank" ng-bind="\'#\' + (issue.nid)"></a>'
+      template: '<a class="kanban-board--issue__link" ng-href="" target="_blank" ng-bind="\'#\' + (issue.nid)"></a>'
     }
   })
   .directive('issueTitle', function () {

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -106,6 +106,7 @@ md-list-item {
   }
   md-card-content {
     padding: 5px 16px;
+    cursor: pointer;
   }
   .md-subhead {
     font-size: 15px;


### PR DESCRIPTION
clarifies the UX and prevents double windows or tabs from opening if you click on the #ISSUE link