### PR TITLE
Fix getting new data from Drupal.org

### DIFF
--- a/app/scripts/services/projectService.js
+++ b/app/scripts/services/projectService.js
@@ -58,7 +58,7 @@
         $http.get(releaseURL.addParameter('field_release_project', nid).getEndpointUrl())
           .then(
             function (d) {
-              var releases = d.list;
+              var releases = d.data.list;
               if (releases.length > 0) {
                 angular.forEach(releases, function (object) {
                   branchLabels.push({
@@ -87,7 +87,7 @@
         $http.get(baseURL.addParameter('field_project_machine_name', machineName).getEndpointUrl())
           .then(function (d) {
             // We did a search
-            var returnedObject = d.list[0];
+            var returnedObject = d.data.list[0];
             if (returnedObject === undefined) {
               alert('Invalid project machine name');
             } else {


### PR DESCRIPTION
Adding a new project didn't work for me.

I looked at the response from drupal.org and noticed that there isn't a `list` property, but there is a `data` property with a `list` property inside it.

Changing these two lines locally (in Chrome Devtools) did the trick. This should also work for others, I assume.