### PR TITLE
Added dependency to fix drush site install error.

### DIFF
--- a/web/modules/custom/contribkanban_api/contribkanban_api.info.yml
+++ b/web/modules/custom/contribkanban_api/contribkanban_api.info.yml
@@ -2,3 +2,7 @@ name: ContribKanban API
 description: API for ContribKanban
 type: module
 core: 8.x
+dependencies:
+  - drupal:jsonapi
+  - drupal:consumers
+  - drupal:simple_oauth


### PR DESCRIPTION
When trying to set up the project. This error occurs. 

```
❯ drush si contribkanban_installer -y

 // You are about to DROP all tables in your '../private/db.sqlite' database. Do you want to continue?: yes.            

 [notice] Starting Drupal installation. This takes a while.
Error: Class 'Drupal\jsonapi\ResourceType\ResourceTypeBuildEvents' not found in /Users/jaykandari/work/contribkanban.com/web/modules/custom/contribkanban_api/src/EventSubscriber/ResourceTypeBuildSubscriber.php on line 18 #0 /Users/jaykandari/work/contribkanban.com/web/core/lib/Drupal/Core/DependencyInjection/Compiler/RegisterEventSubscribersPass.php(37): Drupal\contribkanban_api\EventSubscriber\ResourceTypeBuildSubscriber::getSubscribedEvents()
#1 /Users/jaykandari/work/contribkanban.com/vendor/symfony/dependency-injection/Compiler/Compiler.php(140): Drupal\Core\DependencyInjection\Compiler\RegisterEventSubscribersPass->process(Object(Drupal\Core\DependencyInjection\ContainerBuilder))
...
````
Added a dependency in the profile.info file. 