### PR TITLE
Add PHPUnit config and kernel tests for contribkanban_users

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,20 @@ jobs:
       - run:
           name: phpstan
           command: ./bin/phpstan analyse web/modules/custom --debug
+  phpunit:
+    docker:
+      - image: cimg/php:8.2
+    steps:
+      - setup-build
+      - install-composer
+      - run:
+          name: Create files directory
+          command: mkdir -p web/sites/default/files && chmod 777 web/sites/default/files
+      - run:
+          name: phpunit
+          command: vendor/bin/phpunit web/modules/custom --no-coverage
+          environment:
+            SIMPLETEST_DB: sqlite://localhost//tmp/drupal-test.sqlite
   rector:
     docker:
       - image: cimg/php:8.2
@@ -157,5 +171,6 @@ workflows:
   test:
     jobs:
       - phpstan
+      - phpunit
       - upgrade_status
       - e2e_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
           command: mkdir -p web/sites/default/files && chmod 777 web/sites/default/files
       - run:
           name: phpunit
-          command: vendor/bin/phpunit web/modules/custom --no-coverage
+          command: bin/phpunit web/modules/custom --no-coverage
           environment:
             SIMPLETEST_DB: sqlite://localhost//tmp/drupal-test.sqlite
   rector:

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- For how to customize PHPUnit configuration, see core/tests/README.md. -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="web/core/tests/bootstrap.php" colors="true"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutChangesToGlobalState="true"
+         failOnWarning="true"
+         printerClass="\Drupal\Tests\Listeners\HtmlOutputPrinter"
+         cacheResult="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <php>
+    <ini name="error_reporting" value="32767"/>
+    <ini name="memory_limit" value="-1"/>
+    <env name="SIMPLETEST_BASE_URL" value="https://contribkanban.com.ddev.site"/>
+    <env name="SIMPLETEST_DB" value="sqlite://localhost/sites/default/files/.ht.sqlite"/>
+    <env name="BROWSERTEST_OUTPUT_DIRECTORY" value=""/>
+    <env name="BROWSERTEST_OUTPUT_BASE_URL" value=""/>
+    <env name="MINK_DRIVER_CLASS" value=''/>
+    <env name="MINK_DRIVER_ARGS" value=''/>
+    <env name="MINK_DRIVER_ARGS_WEBDRIVER" value=''/>
+  </php>
+  <testsuites>
+    <testsuite name="unit">
+      <file>web/core/tests/TestSuites/UnitTestSuite.php</file>
+    </testsuite>
+    <testsuite name="kernel">
+      <file>web/core/tests/TestSuites/KernelTestSuite.php</file>
+    </testsuite>
+    <testsuite name="functional">
+      <file>web/core/tests/TestSuites/FunctionalTestSuite.php</file>
+    </testsuite>
+    <testsuite name="functional-javascript">
+      <file>web/core/tests/TestSuites/FunctionalJavascriptTestSuite.php</file>
+    </testsuite>
+    <testsuite name="build">
+      <file>web/core/tests/TestSuites/BuildTestSuite.php</file>
+    </testsuite>
+    <testsuite name="custom">
+      <directory>web/modules/custom/*/tests/src</directory>
+    </testsuite>
+  </testsuites>
+  <listeners>
+    <listener class="\Drupal\Tests\Listeners\DrupalListener">
+    </listener>
+  </listeners>
+  <coverage>
+    <include>
+      <directory>web/modules/custom</directory>
+    </include>
+    <exclude>
+      <directory>web/modules/custom/*/tests</directory>
+    </exclude>
+  </coverage>
+</phpunit>

--- a/web/modules/custom/contribkanban_users/tests/src/Kernel/UserBaseFieldsTest.php
+++ b/web/modules/custom/contribkanban_users/tests/src/Kernel/UserBaseFieldsTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Drupal\Tests\contribkanban_users\Kernel;
+
+use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
+use Drupal\user\Entity\User;
+use GuzzleHttp\Client;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+
+/**
+ * Verifies contribkanban_users adds expected base fields to User entity.
+ *
+ * @group contribkanban_users
+ */
+class UserBaseFieldsTest extends EntityKernelTestBase {
+
+  protected static $modules = ['contribkanban_users'];
+
+  public function testUserBaseFieldsExist(): void {
+    $field_definitions = \Drupal::service('entity_field.manager')
+      ->getBaseFieldDefinitions('user');
+
+    $this->assertArrayHasKey('drupalorg_username', $field_definitions);
+    $this->assertArrayHasKey('drupalorg_uid', $field_definitions);
+    $this->assertArrayHasKey('mail_hash', $field_definitions);
+  }
+
+  public function testDrupalorgUsernameFieldDefinition(): void {
+    $field_definitions = \Drupal::service('entity_field.manager')
+      ->getBaseFieldDefinitions('user');
+
+    $field = $field_definitions['drupalorg_username'];
+    $this->assertEquals('string', $field->getType());
+    $this->assertEquals(255, $field->getSetting('max_length'));
+  }
+
+  public function testDrupalorgUidFieldDefinition(): void {
+    $field_definitions = \Drupal::service('entity_field.manager')
+      ->getBaseFieldDefinitions('user');
+
+    $field = $field_definitions['drupalorg_uid'];
+    $this->assertEquals('string', $field->getType());
+    $this->assertEquals(255, $field->getSetting('max_length'));
+  }
+
+  public function testMailHashFieldIsComputed(): void {
+    $field_definitions = \Drupal::service('entity_field.manager')
+      ->getBaseFieldDefinitions('user');
+
+    $field = $field_definitions['mail_hash'];
+    $this->assertTrue($field->isComputed());
+  }
+
+  public function testPresaveFetchesDrupalorgUidWhenUsernameSet(): void {
+    $stream = $this->createMock(StreamInterface::class);
+    $stream->method('getContents')
+      ->willReturn(json_encode(['list' => [['uid' => '12345']]]));
+
+    $response = $this->createMock(ResponseInterface::class);
+    $response->method('getBody')->willReturn($stream);
+
+    $mock_client = $this->createMock(Client::class);
+    $mock_client->expects($this->once())
+      ->method('get')
+      ->with('user.json?name=mglaman')
+      ->willReturn($response);
+
+    $this->container->set('drupalorg_client', $mock_client);
+
+    $user = User::create([
+      'name' => 'testuser',
+      'mail' => 'test@example.com',
+      'drupalorg_username' => 'mglaman',
+    ]);
+    $user->save();
+
+    $this->assertEquals('12345', $user->get('drupalorg_uid')->value);
+  }
+
+  public function testPresaveSkipsApiCallWhenUidAlreadySet(): void {
+    $mock_client = $this->createMock(Client::class);
+    $mock_client->expects($this->never())->method('get');
+    $this->container->set('drupalorg_client', $mock_client);
+
+    $user = User::create([
+      'name' => 'testuser2',
+      'mail' => 'test2@example.com',
+      'drupalorg_username' => 'mglaman',
+      'drupalorg_uid' => '12345',
+    ]);
+    $user->save();
+
+    $this->assertEquals('12345', $user->get('drupalorg_uid')->value);
+  }
+
+  public function testPresaveSkipsApiCallWhenUsernameEmpty(): void {
+    $mock_client = $this->createMock(Client::class);
+    $mock_client->expects($this->never())->method('get');
+    $this->container->set('drupalorg_client', $mock_client);
+
+    $user = User::create([
+      'name' => 'testuser3',
+      'mail' => 'test3@example.com',
+    ]);
+    $user->save();
+
+    $this->assertTrue($user->get('drupalorg_uid')->isEmpty());
+  }
+
+}


### PR DESCRIPTION
## Summary

- Copies `web/core/phpunit.xml.dist` to repo root as `phpunit.xml` with all paths corrected for running from project root
- Sets `SIMPLETEST_DB` to SQLite for easy local runs
- Adds `UserBaseFieldsTest` kernel test covering:
  - All three base fields (`drupalorg_username`, `drupalorg_uid`, `mail_hash`) exist on User entity
  - Field type and `max_length` settings on `drupalorg_username` and `drupalorg_uid`
  - `mail_hash` is computed
  - `user_presave` fetches Drupal.org UID via API when username set and UID empty
  - `user_presave` skips API call when UID already set
  - `user_presave` skips API call when username empty

## Test plan

- [ ] `ddev exec vendor/bin/phpunit web/modules/custom/contribkanban_users/tests/src/Kernel/UserBaseFieldsTest.php --no-coverage` → 7 tests, all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)