### PR TITLE
Add kernel tests for mail_hash, Project entity, and Scraper

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,5 +5,10 @@ parameters:
 		- */tests/fixtures/*.php
 	paths:
 		- web/modules/custom
+	drupal:
+		entityMapping:
+			project:
+				class: Drupal\contribkanban_projects\Entity\Project
+				storage: Drupal\Core\Entity\Sql\SqlContentEntityStorage
 includes:
 	- phpstan-baseline.neon

--- a/web/modules/custom/contribkanban_projects/tests/src/Kernel/ProjectEntityTest.php
+++ b/web/modules/custom/contribkanban_projects/tests/src/Kernel/ProjectEntityTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Drupal\Tests\contribkanban_projects\Kernel;
+
+use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\contribkanban_projects\Entity\Project;
+use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
+
+/**
+ * Verifies Project entity schema and persistence.
+ *
+ * @group contribkanban_projects
+ */
+class ProjectEntityTest extends EntityKernelTestBase {
+
+  protected static $modules = ['contribkanban_projects', 'contribkanban_api', 'entity'];
+
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('project');
+  }
+
+  public function testProjectBaseFieldsExist(): void {
+    $field_definitions = \Drupal::service('entity_field.manager')
+      ->getBaseFieldDefinitions('project');
+
+    $this->assertArrayHasKey('name', $field_definitions);
+    $this->assertArrayHasKey('machine_name', $field_definitions);
+    $this->assertArrayHasKey('project_type', $field_definitions);
+    $this->assertArrayHasKey('version_format', $field_definitions);
+    $this->assertArrayHasKey('nid', $field_definitions);
+    $this->assertArrayHasKey('components', $field_definitions);
+    $this->assertArrayHasKey('versions', $field_definitions);
+  }
+
+  public function testProjectFieldTypes(): void {
+    $field_definitions = \Drupal::service('entity_field.manager')
+      ->getBaseFieldDefinitions('project');
+
+    foreach (['name', 'machine_name', 'project_type', 'version_format', 'nid', 'components', 'versions'] as $field_name) {
+      $this->assertEquals('string', $field_definitions[$field_name]->getType(), "Field $field_name should be type string.");
+    }
+  }
+
+  public function testComponentsAndVersionsUnlimitedCardinality(): void {
+    $field_definitions = \Drupal::service('entity_field.manager')
+      ->getBaseFieldDefinitions('project');
+
+    $this->assertEquals(
+      BaseFieldDefinition::CARDINALITY_UNLIMITED,
+      $field_definitions['components']->getCardinality()
+    );
+    $this->assertEquals(
+      BaseFieldDefinition::CARDINALITY_UNLIMITED,
+      $field_definitions['versions']->getCardinality()
+    );
+  }
+
+  public function testProjectCreateAndLoad(): void {
+    $project = Project::create([
+      'name' => 'Drupal',
+      'machine_name' => 'drupal',
+      'project_type' => 'full',
+      'nid' => '3060',
+    ]);
+    $project->save();
+
+    $storage = \Drupal::entityTypeManager()->getStorage('project');
+    $loaded = $storage->load($project->id());
+
+    $this->assertEquals('Drupal', $loaded->get('name')->value);
+    $this->assertEquals('drupal', $loaded->get('machine_name')->value);
+    $this->assertEquals('full', $loaded->get('project_type')->value);
+    $this->assertEquals('3060', $loaded->get('nid')->value);
+  }
+
+  public function testProjectMultiValueFields(): void {
+    $project = Project::create([
+      'name' => 'Views',
+      'machine_name' => 'views',
+      'project_type' => 'full',
+      'nid' => '89747',
+      'components' => ['Views UI', 'Views Ajax'],
+    ]);
+    $project->save();
+
+    $storage = \Drupal::entityTypeManager()->getStorage('project');
+    $loaded = $storage->load($project->id());
+
+    $components = array_column($loaded->get('components')->getValue(), 'value');
+    $this->assertContains('Views UI', $components);
+    $this->assertContains('Views Ajax', $components);
+    $this->assertCount(2, $components);
+  }
+
+}

--- a/web/modules/custom/contribkanban_projects/tests/src/Kernel/ProjectEntityTest.php
+++ b/web/modules/custom/contribkanban_projects/tests/src/Kernel/ProjectEntityTest.php
@@ -48,11 +48,11 @@ class ProjectEntityTest extends EntityKernelTestBase {
 
     $this->assertEquals(
       BaseFieldDefinition::CARDINALITY_UNLIMITED,
-      $field_definitions['components']->getCardinality()
+      $field_definitions['components']->getFieldStorageDefinition()->getCardinality()
     );
     $this->assertEquals(
       BaseFieldDefinition::CARDINALITY_UNLIMITED,
-      $field_definitions['versions']->getCardinality()
+      $field_definitions['versions']->getFieldStorageDefinition()->getCardinality()
     );
   }
 
@@ -67,6 +67,7 @@ class ProjectEntityTest extends EntityKernelTestBase {
 
     $storage = \Drupal::entityTypeManager()->getStorage('project');
     $loaded = $storage->load($project->id());
+    $this->assertInstanceOf(Project::class, $loaded);
 
     $this->assertEquals('Drupal', $loaded->get('name')->value);
     $this->assertEquals('drupal', $loaded->get('machine_name')->value);
@@ -86,6 +87,7 @@ class ProjectEntityTest extends EntityKernelTestBase {
 
     $storage = \Drupal::entityTypeManager()->getStorage('project');
     $loaded = $storage->load($project->id());
+    $this->assertInstanceOf(Project::class, $loaded);
 
     $components = array_column($loaded->get('components')->getValue(), 'value');
     $this->assertContains('Views UI', $components);

--- a/web/modules/custom/contribkanban_projects/tests/src/Kernel/ScraperTest.php
+++ b/web/modules/custom/contribkanban_projects/tests/src/Kernel/ScraperTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Drupal\Tests\contribkanban_projects\Kernel;
+
+use Drupal\contribkanban_api\Projects;
+use Drupal\contribkanban_projects\Entity\Project;
+use Drupal\contribkanban_projects\Scraper;
+use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
+
+/**
+ * Verifies Scraper creates and deduplicates Project entities.
+ *
+ * @group contribkanban_projects
+ */
+class ScraperTest extends EntityKernelTestBase {
+
+  protected static $modules = ['contribkanban_projects', 'contribkanban_api', 'entity'];
+
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('project');
+  }
+
+  protected function createScraper(Projects $mock_projects): Scraper {
+    return new Scraper(
+      $mock_projects,
+      \Drupal::service('state'),
+      \Drupal::service('logger.factory')->get('test'),
+      \Drupal::service('entity_type.manager')
+    );
+  }
+
+  protected function projectData(string $machine_name = 'drupal', string $nid = '3060'): array {
+    return [
+      'title'                      => ucfirst($machine_name),
+      'field_project_machine_name' => $machine_name,
+      'field_project_type'         => 'full',
+      'nid'                        => $nid,
+      'field_project_components'   => [],
+    ];
+  }
+
+  public function testScrapeCreatesProjectsFromList(): void {
+    $mock = $this->createMock(Projects::class);
+    $mock->method('getProjects')
+      ->willReturn(['list' => [$this->projectData()]]);
+
+    $this->createScraper($mock)->scrape();
+
+    $results = \Drupal::entityTypeManager()
+      ->getStorage('project')
+      ->loadByProperties(['machine_name' => 'drupal']);
+    $this->assertCount(1, $results);
+  }
+
+  public function testScrapeSkipsExistingProject(): void {
+    Project::create([
+      'name'         => 'Drupal',
+      'machine_name' => 'drupal',
+      'project_type' => 'full',
+      'nid'          => '3060',
+    ])->save();
+
+    $mock = $this->createMock(Projects::class);
+    $mock->method('getProjects')
+      ->willReturn(['list' => [$this->projectData()]]);
+
+    $this->createScraper($mock)->scrape();
+
+    $results = \Drupal::entityTypeManager()
+      ->getStorage('project')
+      ->loadByProperties(['machine_name' => 'drupal']);
+    $this->assertCount(1, $results);
+  }
+
+  public function testScrapeResetsStateOnLastPage(): void {
+    \Drupal::state()->set('project_scraper_last_page', 3);
+
+    $mock = $this->createMock(Projects::class);
+    $mock->method('getProjects')
+      ->willReturn(['list' => [$this->projectData()]]);
+
+    $this->createScraper($mock)->scrape();
+
+    $this->assertEquals(0, \Drupal::state()->get('project_scraper_last_page'));
+  }
+
+  public function testScrapeBreaksWhenEmptyData(): void {
+    $mock = $this->createMock(Projects::class);
+    $mock->method('getProjects')->willReturn([]);
+
+    $this->createScraper($mock)->scrape();
+
+    $results = \Drupal::entityTypeManager()
+      ->getStorage('project')
+      ->loadMultiple();
+    $this->assertCount(0, $results);
+  }
+
+  public function testScrapeAdvancesPageState(): void {
+    $mock = $this->createMock(Projects::class);
+    $mock->method('getProjects')
+      ->willReturnOnConsecutiveCalls(
+        ['list' => [$this->projectData('drupal', '3060')], 'next' => 'page=1'],
+        ['list' => [$this->projectData('views', '89747')]]
+      );
+
+    $this->createScraper($mock)->scrape();
+
+    $this->assertEquals(0, \Drupal::state()->get('project_scraper_last_page'));
+
+    $storage = \Drupal::entityTypeManager()->getStorage('project');
+    $this->assertCount(1, $storage->loadByProperties(['machine_name' => 'drupal']));
+    $this->assertCount(1, $storage->loadByProperties(['machine_name' => 'views']));
+  }
+
+}

--- a/web/modules/custom/contribkanban_users/tests/src/Kernel/UserBaseFieldsTest.php
+++ b/web/modules/custom/contribkanban_users/tests/src/Kernel/UserBaseFieldsTest.php
@@ -65,7 +65,9 @@ class UserBaseFieldsTest extends EntityKernelTestBase {
 
     $field_list = $user->get('mail_hash');
     $this->assertInstanceOf(\Drupal\contribkanban_users\GravatarFieldItemList::class, $field_list);
-    $this->assertEquals(md5('test@example.com'), $field_list->first()->value);
+    $first = $field_list->first();
+    $this->assertNotNull($first);
+    $this->assertEquals(md5('test@example.com'), $first->getValue()['value']);
   }
 
   public function testPresaveFetchesDrupalorgUidWhenUsernameSet(): void {

--- a/web/modules/custom/contribkanban_users/tests/src/Kernel/UserBaseFieldsTest.php
+++ b/web/modules/custom/contribkanban_users/tests/src/Kernel/UserBaseFieldsTest.php
@@ -52,6 +52,22 @@ class UserBaseFieldsTest extends EntityKernelTestBase {
     $this->assertTrue($field->isComputed());
   }
 
+  public function testMailHashFieldUsesGravatarFieldItemList(): void {
+    $mock_client = $this->createMock(Client::class);
+    $mock_client->expects($this->never())->method('get');
+    $this->container->set('drupalorg_client', $mock_client);
+
+    $user = User::create([
+      'name' => 'hashtest',
+      'mail' => 'Test@Example.com',
+    ]);
+    $user->save();
+
+    $field_list = $user->get('mail_hash');
+    $this->assertInstanceOf(\Drupal\contribkanban_users\GravatarFieldItemList::class, $field_list);
+    $this->assertEquals(md5('test@example.com'), $field_list->first()->value);
+  }
+
   public function testPresaveFetchesDrupalorgUidWhenUsernameSet(): void {
     $stream = $this->createMock(StreamInterface::class);
     $stream->method('getContents')


### PR DESCRIPTION
## Summary

- **`UserBaseFieldsTest`**: adds `testMailHashFieldUsesGravatarFieldItemList` — creates a user with mixed-case email, asserts the field list is `GravatarFieldItemList`, and verifies the hash equals `md5(strtolower(trim(email)))`
- **`ProjectEntityTest`** (new): baseline coverage of the `Project` entity — field existence, types, cardinality, create/load round-trip, and multi-value fields
- **`ScraperTest`** (new): baseline coverage of `Scraper` — creates projects from API data, skips duplicates, resets page state after last page, handles empty response

## Test plan

- [ ] `vendor/bin/phpunit web/modules/custom/contribkanban_users/tests/src/Kernel/UserBaseFieldsTest.php` — 8 tests pass
- [ ] `vendor/bin/phpunit web/modules/custom/contribkanban_projects/tests/` — 10 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)