### PR TITLE
Uninstall contribkanban_pages module

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,7 @@ jobs:
           background: true
       - run:
           name: Wait for web server
-          command: dockerize -wait http://127.0.0.1:8080 -timeout 120s
+          command: dockerize -wait http://127.0.0.1:8080/jsonapi -timeout 120s
       - run:
           name: Fetch entrypoint
           command: curl http://127.0.0.1:8080/jsonapi

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -10,7 +10,6 @@ module:
   consumers: 0
   contribkanban_api: 0
   contribkanban_boards: 0
-  contribkanban_pages: 0
   contribkanban_projects: 0
   contribkanban_users: 0
   dynamic_page_cache: 0

--- a/config/system.site.yml
+++ b/config/system.site.yml
@@ -6,8 +6,8 @@ name: ContribKanban.com
 mail: noreply@contribkanban.com
 slogan: ''
 page:
-  403: /not-found
-  404: /not-found
+  403: ''
+  404: ''
   front: /boards
 admin_compact_mode: false
 weight_select_max: 100


### PR DESCRIPTION
## Summary

- All routes in `contribkanban_pages` are dead — superseded by the React SPA after the app went headless
- Cleared `/not-found` as the 403/404 handler in `system.site` (the route is provided by this module)
- Uninstalled the module and exported config

## Follow-up

After this deploys to production, delete `web/modules/custom/contribkanban_pages/` in a separate PR.

## Test plan

- [ ] Verify site loads on production after deploy
- [ ] Confirm 403/404 responses work (Drupal default handling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)