### PR TITLE
Fix: Sprint board creation fails without lists (tag boards) (#529)

### DIFF
--- a/frontend/src/components/Dialogs/CreateProjectDialog.jsx
+++ b/frontend/src/components/Dialogs/CreateProjectDialog.jsx
@@ -42,7 +42,7 @@ function CreateProjectDialog({ open, handleClose }) {
       });
       const json = await res.json();
       if (res.ok) {
-        navigate(`/board/${machineName}`);
+        navigate(`/board/${json.machine_name || machineName}`);
       } else {
         setCurrentState("ERROR");
         setMessage("Error adding board, see console.");

--- a/frontend/src/components/Dialogs/CreateSprintDialog.jsx
+++ b/frontend/src/components/Dialogs/CreateSprintDialog.jsx
@@ -40,7 +40,7 @@ function CreateSprintDialog({ open, handleClose }) {
       method: "POST",
     })
       .then((res) => res.json())
-      .then(() => navigate(`/board/${tagName}`))
+      .then((json) => navigate(`/board/${json.machine_name || tagName}`))
       .catch((err) => {
         setCurrentState("ERROR");
         setMessage("Error adding board, see console.");

--- a/web/modules/custom/contribkanban_api/src/Controller/AddBoard.php
+++ b/web/modules/custom/contribkanban_api/src/Controller/AddBoard.php
@@ -64,7 +64,7 @@ final class AddBoard implements ContainerInjectionInterface {
     if (!empty($existing_board)) {
       $existing_board = reset($existing_board);
       return new JsonResponse([
-        'url' => $existing_board->toUrl()->toString(),
+        'machine_name' => $existing_board->get('machine_name')->value,
       ], 200);
     }
 
@@ -116,7 +116,7 @@ final class AddBoard implements ContainerInjectionInterface {
     $board->save();
 
     return new JsonResponse([
-      'url' => $board->toUrl()->toString(),
+      'machine_name' => $board->get('machine_name')->value,
     ], 201);
   }
 

--- a/web/modules/custom/contribkanban_api/src/Controller/AddTag.php
+++ b/web/modules/custom/contribkanban_api/src/Controller/AddTag.php
@@ -43,14 +43,14 @@ final class AddTag implements ContainerInjectionInterface {
    *
    */
   public function handle($tag) {
-    $tag = urldecode($tag);
-    $tag = $this->tagsHelper->getTag($tag);
+    $tag_name = urldecode($tag);
+    $tag_data = $this->tagsHelper->getTag($tag_name);
     $bundle = 'drupalorg_sprint';
-    $existing_board = $this->boardStorage->loadByProperties(['tag' => $tag['tid'], 'type' => $bundle]);
+    $existing_board = $this->boardStorage->loadByProperties(['tag' => $tag_data['tid'], 'type' => $bundle]);
     if (!empty($existing_board)) {
       $existing_board = reset($existing_board);
       return new JsonResponse([
-        'url' => $existing_board->toUrl()->toString(),
+        'machine_name' => $existing_board->get('machine_name')->value,
       ], 200);
     }
 
@@ -82,8 +82,8 @@ final class AddTag implements ContainerInjectionInterface {
 
     $board = Board::create([
       'type' => $bundle,
-      'title' => $tag['name'],
-      'tag' => [$tag['tid']],
+      'title' => $tag_data['name'],
+      'tag' => [$tag_data['tid']],
       'lists' => [
         $needs_review,
         $needs_work,
@@ -95,7 +95,7 @@ final class AddTag implements ContainerInjectionInterface {
     $board->save();
 
     return new JsonResponse([
-      'url' => $board->toUrl()->toString(),
+      'machine_name' => $board->get('machine_name')->value,
     ], 201);
   }
 


### PR DESCRIPTION
Fixes #529. Modifies board creation so the backend reliably returns the magically generated machine_name, which the frontend then utilizes to fetch to the Search API smoothly.